### PR TITLE
Remove review usefulness normalisation by age; resplit data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@ preprocessing/raw_data/yelp_academic_dataset_*.json
 # joined data
 preprocessing/processed_data/*.parquet.snappy
 
-# No parquet files
-**/*.parquet
+# No parquet / parquet.snappy files
+**/*.parquet*
 
 # fasttextModel
 **/ftt_model/

--- a/preprocessing/combineData.ipynb
+++ b/preprocessing/combineData.ipynb
@@ -20,7 +20,8 @@
    "source": [
     "from pathlib import Path\n",
     "import pandas as pd\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "from sklearn.model_selection import train_test_split"
    ]
   },
   {
@@ -33,7 +34,10 @@
     "ROOT = CWD.parent\n",
     "# path to processed data dir\n",
     "PROC_PATH = CWD/\"processed_data\"\n",
-    "OUTPUT = PROC_PATH / \"preprocessed.parquet.snappy\""
+    "# path to experiment-ready data\n",
+    "READY_DATA_DIR = CWD.parent/\"ready_data\"\n",
+    "\n",
+    "RANDOM_SEED = 2 # for reproducibility"
    ]
   },
   {
@@ -45,15 +49,7 @@
     "main_df = pd.read_parquet(PROC_PATH/\"joined.parquet.snappy\")\n",
     "is_english = pd.read_parquet(PROC_PATH/\"joined_data_lang_detected.parquet\", columns=[\"r_id\", \"is_english\"])\n",
     "is_english = is_english.astype({\"r_id\": int})\n",
-    "linguistic = pd.read_parquet(PROC_PATH/\"joined_linguistic_extra.parquet.snappy\")\n",
-    "\n",
-    "# we assume that the latest review date is the last date of data collection.\n",
-    "# this assumption is supported by the fact that the newest user is also on this\n",
-    "# date. it seems that no more new data is obtained after this date.\n",
-    "\n",
-    "# needs to be obtained before excluding invalid rows.\n",
-    "last_record_date = main_df.r_date.max()\n",
-    "last_record_date_id = main_df.r_id[main_df.r_date.argmax()]"
+    "linguistic = pd.read_parquet(PROC_PATH/\"joined_linguistic_extra.parquet.snappy\")"
    ]
   },
   {
@@ -79,7 +75,7 @@
     "    set(main_df.r_id[main_df.r_date <= main_df.u_yelping_since]))\n",
     "\n",
     "print(f\"excluding: {len(to_exclude)} records\")\n",
-    "main_df = main_df[~main_df.r_id.isin(to_exclude)]\n"
+    "main_df = main_df[~main_df.r_id.isin(to_exclude)]"
    ]
   },
   {
@@ -107,25 +103,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# obtain elapsed month since last data collection date.\n",
-    "month_diff = (last_record_date - main_df.r_date) / np.timedelta64(1, 'M')\n",
-    "# bool mask (need to do this since the indices after exclusion do not match up)\n",
-    "is_last_record_date = main_df.r_id == last_record_date_id\n",
-    "# we add the last record_date by a small number so we don't divide by 0.\n",
-    "month_diff[is_last_record_date] += month_diff[~is_last_record_date].min()\n",
-    "\n",
-    "# scale votes by elapsed months\n",
-    "main_df.r_useful /= month_diff\n",
-    "main_df.r_funny /= month_diff\n",
-    "main_df.r_cool /= month_diff"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# calculate elapsed month since creating account, relative to review post date\n",
     "u_month_age = (main_df.r_date - main_df.u_yelping_since) / np.timedelta64(1, 'M')\n",
     "\n",
@@ -134,17 +111,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
     "# remove unneeded cols\n",
+    "text_df = main_df[[\"r_id\", \"r_text\"]]\n",
     "main_df = main_df.drop(columns=[\"b_id\", \"r_funny\", \"r_cool\", \"u_id\", \"r_date\", \"r_text\", \"u_yelping_since\"])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -198,7 +176,7 @@
        "      <td>0.305871</td>\n",
        "      <td>0.775379</td>\n",
        "      <td>81.59</td>\n",
-       "      <td>0.011830</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -214,7 +192,7 @@
        "      <td>0.027222</td>\n",
        "      <td>0.558611</td>\n",
        "      <td>76.15</td>\n",
-       "      <td>0.014351</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -230,7 +208,7 @@
        "      <td>0.280583</td>\n",
        "      <td>0.489970</td>\n",
        "      <td>70.43</td>\n",
-       "      <td>0.025320</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -246,7 +224,7 @@
        "      <td>0.130754</td>\n",
        "      <td>0.289683</td>\n",
        "      <td>78.59</td>\n",
-       "      <td>0.011194</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -262,7 +240,7 @@
        "      <td>0.236861</td>\n",
        "      <td>0.368667</td>\n",
        "      <td>77.06</td>\n",
-       "      <td>0.028382</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -277,14 +255,14 @@
        "4    19        5              25        78                8              27   \n",
        "\n",
        "   u_month_age  b_stars  b_review_count     r_sen     r_sub  r_rea  r_useful  \n",
-       "0    11.538455      4.0             181  0.305871  0.775379  81.59  0.011830  \n",
-       "1     5.092347      4.5              13  0.027222  0.558611  76.15  0.014351  \n",
-       "2    76.740056      2.5               8  0.280583  0.489970  70.43  0.025320  \n",
-       "3    60.558653      4.0             398  0.130754  0.289683  78.59  0.011194  \n",
-       "4    48.322330      4.0              55  0.236861  0.368667  77.06  0.028382  "
+       "0    11.538455      4.0             181  0.305871  0.775379  81.59         1  \n",
+       "1     5.092347      4.5              13  0.027222  0.558611  76.15         1  \n",
+       "2    76.740056      2.5               8  0.280583  0.489970  70.43         2  \n",
+       "3    60.558653      4.0             398  0.130754  0.289683  78.59         1  \n",
+       "4    48.322330      4.0              55  0.236861  0.368667  77.06         2  "
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -301,12 +279,153 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>r_id</th>\n",
+       "      <th>r_text</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>4</td>\n",
+       "      <td>Wow!  Yummy, different,  delicious.   Our favo...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>9</td>\n",
+       "      <td>This easter instead of going to Lopez Lake we ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>11</td>\n",
+       "      <td>My experience with Shalimar was nothing but wo...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>18</td>\n",
+       "      <td>The hubby and I have been here on multiple occ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>19</td>\n",
+       "      <td>I go to blow bar to get my brows done by natal...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   r_id                                             r_text\n",
+       "0     4  Wow!  Yummy, different,  delicious.   Our favo...\n",
+       "1     9  This easter instead of going to Lopez Lake we ...\n",
+       "2    11  My experience with Shalimar was nothing but wo...\n",
+       "3    18  The hubby and I have been here on multiple occ...\n",
+       "4    19  I go to blow bar to get my brows done by natal..."
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "text_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# split df into train and remainder. Shuffles before split\n",
+    "train_main_df, remainder_main_df, train_text_df, remainder_text_df = train_test_split(\n",
+    "    main_df, text_df, train_size=0.8, random_state=RANDOM_SEED)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# split remainder into val and test. Shuffles before split\n",
+    "val_main_df, test_main_df, val_text_df, test_text_df = train_test_split(\n",
+    "    remainder_main_df, remainder_text_df, train_size=0.5, random_state=RANDOM_SEED)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.7999998447074151 0.09999988353056138 0.10000027176202343\n",
+      "0.7999998447074151 0.09999988353056138 0.10000027176202343\n",
+      "True\n",
+      "True\n",
+      "True\n",
+      "True\n",
+      "True\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# validate created splits proportions. should be about 0.8, 0.1, 0.1\n",
+    "print(len(train_main_df) / len(main_df), len(val_main_df) / len(main_df), len(test_main_df) / len(main_df))\n",
+    "print(len(train_text_df) / len(main_df), len(val_text_df) / len(main_df), len(test_text_df) / len(main_df))\n",
+    "# check records align in main df and text\n",
+    "print(np.all(train_main_df.index == train_text_df.index)) # want: TRUE\n",
+    "print(np.all(val_main_df.index == val_text_df.index)) # want: TRUE\n",
+    "print(np.all(test_main_df.index == test_text_df.index)) # want: TRUE\n",
+    "# check uniqueness of records\n",
+    "print(len(np.intersect1d(train_main_df.index, val_main_df.index)) == 0) # want: TRUE\n",
+    "print(len(np.intersect1d(train_main_df.index, test_main_df.index)) == 0) # want: TRUE\n",
+    "print(len(np.intersect1d(val_main_df.index, test_main_df.index)) == 0) # want: TRUE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# save output\n",
-    "main_df.to_parquet(OUTPUT)"
+    "train_main_df.to_parquet(READY_DATA_DIR/\"train_main.parquet.snappy\", index=False)\n",
+    "train_text_df.to_parquet(READY_DATA_DIR/\"train_text.parquet.snappy\", index=False)\n",
+    "\n",
+    "val_main_df.to_parquet(READY_DATA_DIR/\"val_main.parquet.snappy\", index=False)\n",
+    "val_text_df.to_parquet(READY_DATA_DIR/\"val_text.parquet.snappy\", index=False)\n",
+    "\n",
+    "test_main_df.to_parquet(READY_DATA_DIR/\"test_main.parquet.snappy\", index=False)\n",
+    "test_text_df.to_parquet(READY_DATA_DIR/\"test_text.parquet.snappy\", index=False)"
    ]
   }
  ],


### PR DESCRIPTION
Previously the usefulness votes were normalised by age i.e. each review's usefulness votes divided by the age of the review at the time of data collection. However, data collection date was potentially erroneously assumed to be constant and on the date of the latest review.

The reality is that there is no data collection date information in the dataset, so the best we can do is just not normalise by review age. Attempting to do so may introduce bias.